### PR TITLE
Fix/ontriggerStay 인식 콜라이더 배열로 수정 작업 진행

### DIFF
--- a/Assets/1.Private/LimJY/Scenes/LJY_Test.unity
+++ b/Assets/1.Private/LimJY/Scenes/LJY_Test.unity
@@ -219,7 +219,52 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &901156827
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 901156829}
+  - component: {fileID: 901156828}
+  m_Layer: 0
+  m_Name: Numbering
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &901156828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901156827}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b28dd60f6abf16d4094cf0f642a043e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dontDestroyOnLoad: 1
+--- !u!4 &901156829
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901156827}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 910.975, y: 577.51825, z: 1.9635065}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &969358648
 GameObject:
@@ -612,6 +657,37 @@ MonoBehaviour:
   m_ShadowLayerMask: 1
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
+--- !u!1 &1658979025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1658979026}
+  m_Layer: 0
+  m_Name: ====================== (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1658979026
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1658979025}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.0343157, y: 1.0432571, z: 5.8509297}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1745825586
 GameObject:
   m_ObjectHideFlags: 0
@@ -816,7 +892,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2113610241
 GameObject:

--- a/Assets/1.Private/LimJY/Scripts/OBJ_Crown.cs
+++ b/Assets/1.Private/LimJY/Scripts/OBJ_Crown.cs
@@ -28,13 +28,13 @@ public class OBJ_Crown : MonoBehaviour
         }
     }
 
-    private void OnTriggerStay(Collider other)
-    {
-        if (other.CompareTag("Player"))
-        {
-            CrownDisable(other.gameObject);
-        }
-    }
+    //private void OnTriggerStay(Collider[] other)
+    //{
+    //    //if (other[].CompareTag("Player"))
+    //    //{
+
+    //    //}
+    //}
 
     private void OnTriggerExit(Collider other)
     {
@@ -48,14 +48,23 @@ public class OBJ_Crown : MonoBehaviour
     // -------------------------------------------------------------------------
 
     /// <summary>
-    /// 왕관 오브젝트 비활성화 조건
+    /// 왕관 오브젝트 비활성화
     /// <summary>
-    void CrownDisable(GameObject Player)
+    void CrownDisable(GameObject[] Player)
     {
         if (IsGrabEnable)
         {
             // 잡기 기능이 활성화 상태일 때,
             // Player의 State가 grab으로 변경 시, 왕관 오브젝트를 비활성화 한다.
+            /*
+
+                for (int i = 0; i < Player.Length; i++)
+                {
+                    if (Player.PlayerController.State !=  State.Grab) return;
+
+                    PlayerWinner = Player[i];
+                }
+             */
             gameObject.SetActive(false); // 추후 if문 사용 예정
         }
         else
@@ -81,6 +90,7 @@ public class OBJ_Crown : MonoBehaviour
 
         // PlayerWinner.animator.Play(우승 모션 재생);
         StartCoroutine(ShortLoadingPlay());
+
     }
 
     IEnumerator ShortLoadingPlay()


### PR DESCRIPTION
왕관 오브젝트 colider에 여러 플레이어 오브젝트가 있을 경우를 대비하여, 인식할 수 있는 콜라이더의 범위를 넓힘